### PR TITLE
(feat): operator: add ability to choose an l1 block

### DIFF
--- a/operator/src/types.rs
+++ b/operator/src/types.rs
@@ -97,8 +97,5 @@ pub struct Validators {
 #[derive(Debug, Deserialize)]
 
 pub struct Validator {
-    #[serde(rename = "ID")]
-    pub id: u64,
-    pub power: u64,
-    pub signer: String,
+    pub last_updated: String,
 }

--- a/operator/src/utils.rs
+++ b/operator/src/utils.rs
@@ -109,4 +109,26 @@ impl PosClient {
             .await?;
         Ok(response)
     }
+
+    pub async fn fetch_validator_set_by_height(&self, height: u64) -> Result<ValidatorSetResponse> {
+        let url: String = format!(
+            "{}/staking/validator-set?height={}",
+            self.heimdall_url, height
+        );
+        println!("Fetching validator set at height from: {}", url);
+        let response = self
+            .http_client
+            .get(url)
+            .headers(self.headers.clone())
+            .send()
+            .await?;
+        let json_response = response.json::<ValidatorSetResponse>().await;
+        if json_response.is_ok() {
+            Ok(json_response?)
+        } else {
+            println!("Failed to fetch validator set at height, please use an archive node. Using latest block instead");
+            let response = self.fetch_validator_set().await?;
+            Ok(response)
+        }
+    }
 }


### PR DESCRIPTION
This PR adds ability to choose an L1 block for proof generation. 

Rationale:
The `/staking/validator-set` endpoint of heimdall returns list of validators which has a field called `last_updated` representing a value denoting the recent most L1 block number when the stake was updated for a particular validator. The value is obtained by `block_number * 100000 + tx_log_index`. Hence, on dividing this value by `100k`, we get the block number when a particular validator's stake was updated and we choose the max out of it. 

Because we can't verify all blocks in solidity, we also have to check if this block we derived is in that limit or not. If not, we choose the latest block. The next step is to also check if there was any stake update on L1 between the max block and current block. If there's any, we'll have to choose a number lower that that block instead. 