### PR TITLE
(feat): enforce usage of recent L1 block in circuit

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -26,6 +26,7 @@ pub struct PoSConsensusInput {
 
     // l1 related data
     pub state_sketch_bytes: Vec<u8>,
+    pub l1_block_header: Header,
     pub l1_block_hash: B256,
     pub stake_info_address: Address,
 }


### PR DESCRIPTION
L1 block hash plays a very crucial part as it's used a source of truth for active validator set and stake. All the calls to L1 are made using this block hash. 

Previously, the prover can use any valid L1 block hash and generate valid proof. This is not ideal as the prover can use an old block hash such that it points to a specific (old) validator set and stake distribution and generate malicious proofs even when such milestone doesn't exist in heimdall. 

While, there's no ideal solution to this (because we have no way to fully ensure this in circuit), but we can make use of timestamp to ensure recent-ness of the L1 block being used. While this still gives the prover a chance to do malicious actions, an old L1 block can only be chosen until a specific time has passed (set to 3 hours as of now). Note that malicious actions here aren't security risks technically because we're still using a valid L1 block. 

Because we can't use system time inside zkVM, we'll compare the timestamp with a bor block.  